### PR TITLE
Remove metrics from export template

### DIFF
--- a/templates/dmp/root.html.j2
+++ b/templates/dmp/root.html.j2
@@ -64,7 +64,6 @@
   <section class="report">
     <h3 class="title">Report</h3>
     {{renderIndications(chapter)}}
-    {{renderMetrics(chapter)}}
   </section>
 {%- endmacro -%}
 


### PR DESCRIPTION
Remove directly from html template. Future improvement: make this configurable from the app-config.